### PR TITLE
Fixing latency for linux axis events.

### DIFF
--- a/src/ofxGamepadLinux.cpp
+++ b/src/ofxGamepadLinux.cpp
@@ -48,16 +48,17 @@ ofxGamepadLinux::~ofxGamepadLinux() {
 
 void ofxGamepadLinux::update() {
 	struct js_event event;
-	read(fd, &event, sizeof(struct js_event));
+	while (read(fd, &event, sizeof(struct js_event)) > 0) {
 
-	/* see what to do with the event */
-	switch (event.type & ~JS_EVENT_INIT) {
-	case JS_EVENT_AXIS:
+	    /* see what to do with the event */
+	    switch (event.type & ~JS_EVENT_INIT) {
+	      case JS_EVENT_AXIS:
 		axisChanged(event.number, event.value);
 		break;
-	case JS_EVENT_BUTTON:
+	      case JS_EVENT_BUTTON:
 		buttonChanged(event.number, event.value);
 		break;
+	    }
 	}
 
 }


### PR DESCRIPTION
Read the joypad device file till it's empty on each update. This makes
sure we don't get a backlog of joypad events, which can introduce
latency.
# 

I have been seeing latency of ~1 second on axis input on my laptop - Ubuntu 12.04 with a wired XBox 360 controller. This change seems to fix it.
